### PR TITLE
Fix: Ubuntu support

### DIFF
--- a/demoRMR/demoRMR.pro
+++ b/demoRMR/demoRMR.pro
@@ -61,7 +61,8 @@ win32 {
 unix {
     PKGCONFIG += opencv4
 
-INCLUDEPATH += /usr/local/include/opencv4/
+    INCLUDEPATH += /usr/include/opencv4/
+    INCLUDEPATH += /usr/local/include/opencv4/
 
     LIBS += -L/usr/local/lib/        \
         -l:libopencv_core.so       \

--- a/demoRMR/main.cpp
+++ b/demoRMR/main.cpp
@@ -1,6 +1,8 @@
 #include "mainwindow.h"
 #include <QApplication>
+#ifdef _WIN32
 #include "mmsystem.h"
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/robot/robot.pro
+++ b/robot/robot.pro
@@ -52,7 +52,8 @@ win32 {
 unix {
     PKGCONFIG += opencv4
 
-INCLUDEPATH += /usr/local/include/opencv4/
+    INCLUDEPATH += /usr/local/include/opencv4/
+    INCLUDEPATH += /usr/include/opencv4/
 
     LIBS += -L/usr/local/lib/        \
         -l:libopencv_core.so       \


### PR DESCRIPTION
Fixed building the repository on Ubuntu 20.04:
- include `mmsystem.h` only on Windows
- added extra include path for OpenCV in `/usr/local/include/opencv4/`